### PR TITLE
CRM-91: approach with dynamic parsing service name from resourceId

### DIFF
--- a/terraform-azure-datadog-log-forwarder/README.md
+++ b/terraform-azure-datadog-log-forwarder/README.md
@@ -10,7 +10,6 @@ Forwarding logs received from eventhub to datadog.
 * __subscription_id__: id of Azure Subscription, where all Azure Resources should be build
 * __datadog_api_key__: target DD Api Key for forwarded logs
 * __dd_tags__: custom datadog tags attached to logs additionally to tags _subscription_id_, _resource_group_ and _forwardername_
-* __dd_service__: custom service tag; if no setted, default will be "azure"
 
 _Example of usage:_
 

--- a/terraform-azure-datadog-log-forwarder/log-forwarder-func.tf
+++ b/terraform-azure-datadog-log-forwarder/log-forwarder-func.tf
@@ -94,7 +94,6 @@ resource "azurerm_function_app" "datadog" {
     DD_SITE                     = "datadoghq.eu"
     DATADOG_EVENTHUB_CONNECTION = "${azurerm_eventhub_namespace.datadog.default_primary_connection_string};EntityPath=datadog"
     DD_TAGS                     = var.dd_tags
-    DD_SERVICE                  = var.dd_service
   }
 
   depends_on = [

--- a/terraform-azure-datadog-log-forwarder/variables.tf
+++ b/terraform-azure-datadog-log-forwarder/variables.tf
@@ -25,10 +25,6 @@ variable "dd_tags" {
   type = string
 }
 
-variable "dd_service" {
-  type = string
-}
-
 variable "subscription_id" {
   type = string
 }


### PR DESCRIPTION
Approach with dynamic parsing service name from resourceId.

PR for previous solution closed, because considered to be sub-optimal: https://github.com/edekadigital/terraform-azure-modules/pull/3

Solution here should be quite robust, if consider structure convention of Azure resourceId.

Why?

- for cases, provider is a part of the resourceId, which should be the case for Azure Web and Function Apps,(MICROSOFT.WEB f.e. in case of Azure Web Apps and Functions App - s. also attached screenshot), service name should reliably be at last index of parsed Azure resourceId
- For all another cases, service is set to default "azure" value

In general, this should be enough for our purposes, because this kind of log forwarding (via event hub) is only applicable for Azure Web Apps and Function Apps (I speak mainly about monitorable Azure Compute Services). For VMs and Azure Containers another log shipping approaches are used, like Docker Agent / Fluent Bit Sidecar Container.

By the way, we use same approach in our AWS Lambda Log Forwarder, I took a look there.

<img width="1440" alt="azure_docu" src="https://user-images.githubusercontent.com/28353559/114211902-7f352980-9961-11eb-918c-222e12b92060.png">
