### PR TITLE
Fixes volume name for ssh host keys

### DIFF
--- a/terraform-azure-sftp/sftp-service.tf
+++ b/terraform-azure-sftp/sftp-service.tf
@@ -21,7 +21,7 @@ resource "azurerm_container_group" "sftp" {
 
     # https://github.com/atmoz/sftp#providing-your-own-ssh-host-key-recommended
     volume {
-      name       = "ssh_host_keys"
+      name       = "ssh-host-keys"
       mount_path = "/etc/ssh"
       read_only  = true
       secret = {


### PR DESCRIPTION
Fixes error while deploying:


The volume name 'ssh_host_keys' is invalid. The volume name must match the regex '[a-z0-9]([-a-z0-9]*[a-z0-9])?' (e.g. 'my-name')