### PR TITLE
Add new feature to use existing ressource group for all datadog azure…

### DIFF
--- a/terraform-azure-datadog-log-forwarder/README.md
+++ b/terraform-azure-datadog-log-forwarder/README.md
@@ -5,6 +5,7 @@ Forwarding logs received from eventhub to datadog.
 # Input variables to module
 * __resource_location__: default is `West Europe`
 * __project_name_as_resource_prefix__: project name as prefix for all created Azure Resources
+* __existing_ressource_group__: already existing ressource group can be used, new ressource group will not be created
 * __eventhub_message_retention__: retention for log events within Event Hub. Default is 1 day
 * __eventhub_partition_count__: partition count for Event Hub. Defaults to 4
 * __datadog_api_key__: target DD Api Key for forwarded logs

--- a/terraform-azure-datadog-log-forwarder/azure-eventhub.tf
+++ b/terraform-azure-datadog-log-forwarder/azure-eventhub.tf
@@ -1,7 +1,7 @@
 data "azurerm_eventhub_namespace_authorization_rule" "datadog" {
   name                = "RootManageSharedAccessKey"
   namespace_name      = azurerm_eventhub_namespace.datadog.name
-  resource_group_name = azurerm_resource_group.datadog.name
+  resource_group_name = local.ressource_group_name
 
   depends_on = [
   azurerm_eventhub_namespace.datadog]
@@ -10,7 +10,7 @@ data "azurerm_eventhub_namespace_authorization_rule" "datadog" {
 resource "azurerm_eventhub_namespace" "datadog" {
   name                = "${var.project_name_as_resource_prefix}-datadog-evhn"
   location            = var.resource_location
-  resource_group_name = azurerm_resource_group.datadog.name
+  resource_group_name = local.ressource_group_name
   sku                 = "Basic"
   capacity            = 1
   tags                = var.azure_tags
@@ -19,7 +19,7 @@ resource "azurerm_eventhub_namespace" "datadog" {
 resource "azurerm_eventhub" "datadog" {
   name                = "datadog"
   namespace_name      = azurerm_eventhub_namespace.datadog.name
-  resource_group_name = azurerm_resource_group.datadog.name
+  resource_group_name = local.ressource_group_name
   message_retention   = var.eventhub_message_retention
   partition_count     = var.eventhub_partition_count
 }

--- a/terraform-azure-datadog-log-forwarder/azure-log-forwarder-func.tf
+++ b/terraform-azure-datadog-log-forwarder/azure-log-forwarder-func.tf
@@ -12,8 +12,8 @@ data "archive_file" "app_code_datadog" {
 
 resource "azurerm_storage_account" "datadog" {
   name                      = replace("${var.project_name_as_resource_prefix}-dd-st", "-", "")
-  resource_group_name       = azurerm_resource_group.datadog.name
-  location                  = azurerm_resource_group.datadog.location
+  resource_group_name       = local.ressource_group_name
+  location                  = var.resource_location
   account_tier              = "Standard"
   account_replication_type  = "LRS"
   enable_https_traffic_only = true
@@ -56,13 +56,13 @@ data "azurerm_storage_account_sas" "sas_deploy_datadog" {
 // It is necessary to manually sync the function app triggers after deployment, see README
 data "azurerm_function_app_host_keys" "datadog" {
   name                = azurerm_function_app.datadog.name
-  resource_group_name = azurerm_resource_group.datadog.name
+  resource_group_name = local.ressource_group_name
 }
 
 resource "azurerm_app_service_plan" "datadog" {
   name                = "${var.project_name_as_resource_prefix}-datadog-plan"
   location            = var.resource_location
-  resource_group_name = azurerm_resource_group.datadog.name
+  resource_group_name = local.ressource_group_name
   kind                = "FunctionApp"
   reserved            = true
 
@@ -77,7 +77,7 @@ resource "azurerm_app_service_plan" "datadog" {
 resource "azurerm_function_app" "datadog" {
   name                       = "${var.project_name_as_resource_prefix}-datadog-func"
   location                   = var.resource_location
-  resource_group_name        = azurerm_resource_group.datadog.name
+  resource_group_name        = local.ressource_group_name
   app_service_plan_id        = azurerm_app_service_plan.datadog.id
   storage_account_name       = azurerm_storage_account.datadog.name
   storage_account_access_key = azurerm_storage_account.datadog.primary_access_key
@@ -118,7 +118,7 @@ resource "azurerm_function_app" "datadog" {
 resource "azurerm_application_insights" "datadog" {
   name                = "${var.project_name_as_resource_prefix}-datadog-app-insights"
   location            = var.resource_location
-  resource_group_name = azurerm_resource_group.datadog.name
+  resource_group_name = local.ressource_group_name
   application_type    = "Node.JS"
   tags                = var.azure_tags
 }

--- a/terraform-azure-datadog-log-forwarder/azure-resource-group.tf
+++ b/terraform-azure-datadog-log-forwarder/azure-resource-group.tf
@@ -1,4 +1,6 @@
 resource "azurerm_resource_group" "datadog" {
+  count = var.existing_ressource_group == "" ? 1 : 0
+
   name     = "${var.project_name_as_resource_prefix}-datadog-rg"
   location = var.resource_location
   tags     = var.azure_tags

--- a/terraform-azure-datadog-log-forwarder/variables.tf
+++ b/terraform-azure-datadog-log-forwarder/variables.tf
@@ -3,6 +3,12 @@ variable "project_name_as_resource_prefix" {
   type        = string
 }
 
+variable "existing_ressource_group" {
+  description = "Use an already existing ressource group for all Azure resources"
+  type        = string
+  default     = ""
+}
+
 variable "datadog_api_key" {
   description = "API key for datadog"
   type        = string
@@ -113,6 +119,8 @@ variable "eventhub_partition_count" {
 }
 
 locals {
-  datadog_tags          = [for k, v in var.datadog_tags : "${k}:${v}"]
-  datadog_monitors_tags = [for k, v in var.datadog_monitors_tags : "${k}:${v}"]
+  datadog_tags                  = [for k, v in var.datadog_tags : "${k}:${v}"]
+  datadog_monitors_tags         = [for k, v in var.datadog_monitors_tags : "${k}:${v}"]
+  assigned_ressource_group_name = "${var.project_name_as_resource_prefix}-datadog-rg"
+  ressource_group_name          = "${var.existing_ressource_group != "" ? var.existing_ressource_group : local.assigned_ressource_group_name}"
 }

--- a/terraform-azure-datadog-log-forwarder/variables.tf
+++ b/terraform-azure-datadog-log-forwarder/variables.tf
@@ -122,5 +122,5 @@ locals {
   datadog_tags                  = [for k, v in var.datadog_tags : "${k}:${v}"]
   datadog_monitors_tags         = [for k, v in var.datadog_monitors_tags : "${k}:${v}"]
   assigned_ressource_group_name = "${var.project_name_as_resource_prefix}-datadog-rg"
-  ressource_group_name          = "${var.existing_ressource_group != "" ? var.existing_ressource_group : local.assigned_ressource_group_name}"
+  ressource_group_name          = var.existing_ressource_group != "" ? var.existing_ressource_group : local.assigned_ressource_group_name
 }


### PR DESCRIPTION
Add new feature to use an already existing ressource group for creating all datadog ressources. 
If variable existing_ressource_group  is set e.g. "davids_mega_geile_ressource_gruppe" all datadog ressources will be created inside this ressource group. If the Variable is ignored, the ressource groub will be automatically created and all datadog ressource will be ccreated inside this new group. 